### PR TITLE
delete baseUrl in tsconfig.json

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,6 @@
     "esModuleInterop": true,
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
-    "baseUrl": "."
   },
   "exclude": [
     "node_modules"


### PR DESCRIPTION
Since the template builds js and runs js in production rather than runs ts in production, some imports auto-generated may lead to some import errors when running built js.