### PR TITLE
fix(fastify): deprecated .listen(port) requires change

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import app from "./app";
 
 const FASTIFY_PORT = Number(process.env.FASTIFY_PORT) || 3006;
 
-app.listen(FASTIFY_PORT);
+app.listen({ port: FASTIFY_PORT });
 
 console.log(`🚀  Fastify server running on port ${FASTIFY_PORT}`);
 console.log(`Route index: /`);


### PR DESCRIPTION
Fastify emits a warning at v4:

```
(node:11202) [FSTDEP011] FastifyDeprecation: Variadic listen method is deprecated. Please use ".listen(optionsObject)" instead. The variadic signature will be removed in `fastify@5`.
(Use `node --trace-warnings ...` to show where the warning was created)
```

This pr simply changes it to an options object