### PR TITLE
feat:(env type safe) - add zod validation & declare type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 dist
 node_modules
 .vscode
+.env

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,8 @@
         "prettier": "^3.2.4",
         "rimraf": "^5.0.5",
         "tsconfig-paths": "^4.2.0",
-        "typescript": "^5.3.3"
+        "typescript": "^5.3.3",
+        "zod": "^3.22.4"
       }
     },
     "node_modules/@fastify/ajv-compiler": {
@@ -1557,6 +1558,15 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+    },
+    "node_modules/zod": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.4.tgz",
+      "integrity": "sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "prettier": "^3.2.4",
     "rimraf": "^5.0.5",
     "tsconfig-paths": "^4.2.0",
-    "typescript": "^5.3.3"
+    "typescript": "^5.3.3",
+    "zod": "^3.22.4"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,8 @@ const FASTIFY_PORT = Number(process.env.FASTIFY_PORT) || 3006;
 
 app.listen({ port: FASTIFY_PORT });
 
-console.log(`🚀  Fastify server running on port http://localhost:${FASTIFY_PORT}`);
+console.log(
+  `🚀  Fastify server running on port http://localhost:${FASTIFY_PORT}`
+);
 console.log(`Route index: /`);
 console.log(`Route user: /api/v1/user`);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,6 +18,7 @@
     "node_modules"
   ],
   "include": [
-    "./src/**/*.ts"
+    "./src/**/*.ts",
+    "type.env.ts"
   ]
 }

--- a/type.env.ts
+++ b/type.env.ts
@@ -1,0 +1,22 @@
+/**
+ *
+ * Simple configuration that enables type-safe reading of environment variables
+ * & provides auto-completion support in VSCode.
+ * Matt Pocock did a video explaining how you can implement this approach:
+ * see https://www.youtube.com/watch?v=q1im-hMlKhM
+ */
+
+import z from "zod";
+
+const envVariables = z.object({
+  FASTIFY_PORT: z.string(),
+  DATABASE_URL: z.string(),
+});
+
+envVariables.parse(process.env);
+
+declare global {
+  namespace NodeJS {
+    interface ProcessEnv extends z.infer<typeof envVariables> {}
+  }
+}


### PR DESCRIPTION
 adding Simple configuration that enables type-safe reading of environment variables
 & provides auto-completion support in VSCode.
 Matt Pocock did a video explaining how you can implement this approach:
[ **[see the video]** ](https://www.youtube.com/watch?v=q1im-hMlKhM)